### PR TITLE
Updated `Remix` file convention to allow for `Remix v1` file convention

### DIFF
--- a/remix.config.js
+++ b/remix.config.js
@@ -13,6 +13,6 @@ module.exports = {
     v2_errorBoundary: true,
     v2_meta: true,
     v2_normalizeFormMethod: true,
-    v2_routeConvention: true,
+    v2_routeConvention: false,
   },
 };


### PR DESCRIPTION
## Summary
Updated `Remix` config to allow us to use `v1` file conventions
Enabling `v1` file conventions will allow us to structure our files like this
```
app/
├── routes/
│   ├── blog/
│   │   ├── $postId.tsx
│   │   ├── categories.tsx
│   │   └── index.tsx
│   ├── about.tsx
│   └── index.tsx
└── root.tsx

```
rather than using the `dot` notation in `v2
```
app/
├── routes/
│   ├── _index.tsx
│   ├── about.tsx
│   ├── concerts.$city.tsx
│   └── concerts.trending.tsx
└── root.tsx

```

## Resources
- Remix https://stackoverflow.com/questions/75933195/remixjs-nested-routes-not-found
- Remix `v1` file convention: https://remix.run/docs/en/1.15.0/file-conventions/routes-files
- Remix `v2` file convention: https://remix.run/docs/en/1.15.0/file-conventions/route-files-v2