### PR TITLE
[Feature] Integrated feature for users to add/edit the titles of their Images

### DIFF
--- a/app/client/getImageBlob/getImageBlob.ts
+++ b/app/client/getImageBlob/getImageBlob.ts
@@ -1,21 +1,8 @@
 export const getImageBlob = async (imageId: string) => {
-  const response = await fetch(`/api/image/${imageId}`);
   console.log("Get Image Blob Response ----------------------");
+  const response = await fetch(`/api/image/${imageId}`);
   console.log(response);
   const data = await response.json();
-  console.log(data);
-
-  console.log("Get Image Blob Response ----------------------");
-
-  // const data = await fetch(imageURL)
-  //   .then((response) => {
-  //     return response.blob();
-  //   })
-  //   .then((blob) => {
-  //     return URL.createObjectURL(blob);
-  //   });
-
-  // console.log(data);
 
   return data;
 };

--- a/app/components/ImageModal/ImageModal.tsx
+++ b/app/components/ImageModal/ImageModal.tsx
@@ -128,7 +128,7 @@ const ImageModal = ({
           </Space>
           <Space style={{ display: "flex", justifyContent: "space-between" }}>
             <Typography.Text strong style={{ fontSize: 16 }}>
-              {imageData.title || "Undefined"}
+              {imageData.title || "Untitled"}
             </Typography.Text>
             <LikeImageButton imageData={imageData} />
           </Space>

--- a/app/pages/CreationsPage/CreationsPage.tsx
+++ b/app/pages/CreationsPage/CreationsPage.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   Popover,
   type RadioChangeEvent,
+  Tooltip,
 } from "antd";
 import type { ImageType } from "~/types";
 import {
@@ -26,6 +27,7 @@ import {
   EditImageButton,
 } from "./components";
 import { ImageModal, LikeImageButton } from "~/components";
+import { convertUtcDateToLocalDateString } from "~/utils";
 
 const CreationsPage = () => {
   const data = useLoaderData();
@@ -102,25 +104,26 @@ const CreationsPage = () => {
                         justifyContent: "space-between",
                       }}
                     >
-                      <Typography.Text
-                        ellipsis={{
-                          tooltip: (
-                            <Typography.Text>
+                      <Tooltip
+                        title={
+                          <Typography.Text>
+                            {image.title}
+                            <br />
+                            <Typography.Text italic>
                               {image.prompt}
                               <br />
                               <br />
-                              <Typography.Text italic>
-                                Created By: {image.user.username}
-                                <br />
-                                {new Date(image.createdAt).toLocaleString()}
-                              </Typography.Text>
+                              Created By: {image.user.username}
+                              <br />
+                              {convertUtcDateToLocalDateString(image.createdAt)}
                             </Typography.Text>
-                          ),
-                        }}
-                        style={{ maxWidth: 160 }}
+                          </Typography.Text>
+                        }
                       >
-                        {image.prompt}
-                      </Typography.Text>
+                        <Typography.Text ellipsis style={{ maxWidth: 160 }}>
+                          {image.title || "Untitled"}
+                        </Typography.Text>
+                      </Tooltip>
                       <Popover
                         content={
                           <Space size='small'>
@@ -168,25 +171,42 @@ const CreationsPage = () => {
               >
                 <List.Item.Meta
                   avatar={<ImageModal imageData={image} />}
-                  title={image.prompt}
+                  title={image.title || "Untitled"}
                   description={
-                    <div
-                      style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                      }}
-                    >
-                      <div>
-                        <LikeImageButton imageData={image} />
-                        <Space style={{ color: "#64ffda" }}>
-                          <MessageOutlined />
-                          {image.comments.length > 0 && image.comments.length}
+                    <>
+                      <div
+                        style={{
+                          display: "flex",
+                          flexDirection: "column",
+                          justifyContent: "space-between",
+                        }}
+                      >
+                        <Typography.Text italic style={{ marginBottom: 8 }}>
+                          {image.prompt}
+                        </Typography.Text>
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            marginBottom: 8,
+                          }}
+                        >
+                          <Typography.Text>
+                            Created By: {image.user.username}
+                          </Typography.Text>
+                          <Typography.Text italic>
+                            {convertUtcDateToLocalDateString(image.createdAt)}
+                          </Typography.Text>
+                        </div>
+                        <Space>
+                          <LikeImageButton imageData={image} />
+                          <Space style={{ color: "#64ffda" }}>
+                            <MessageOutlined />
+                            {image.comments.length > 0 && image.comments.length}
+                          </Space>
                         </Space>
                       </div>
-                      <Typography.Text italic>
-                        {new Date(image.createdAt).toLocaleString()}
-                      </Typography.Text>
-                    </div>
+                    </>
                   }
                 />
               </List.Item>

--- a/app/pages/CreationsPage/CreationsPage.tsx
+++ b/app/pages/CreationsPage/CreationsPage.tsx
@@ -20,7 +20,11 @@ import {
   type RadioChangeEvent,
 } from "antd";
 import type { ImageType } from "~/types";
-import { DeleteImageButton, DownloadImageButton } from "./components";
+import {
+  DeleteImageButton,
+  DownloadImageButton,
+  EditImageButton,
+} from "./components";
 import { ImageModal, LikeImageButton } from "~/components";
 
 const CreationsPage = () => {
@@ -121,6 +125,7 @@ const CreationsPage = () => {
                         content={
                           <Space size='small'>
                             <Space.Compact direction='vertical'>
+                              <EditImageButton image={image} />
                               <DownloadImageButton image={image} />
                               <DeleteImageButton image={image} />
                             </Space.Compact>
@@ -155,6 +160,7 @@ const CreationsPage = () => {
                 key={image.id}
                 extra={
                   <Space>
+                    <EditImageButton image={image} />
                     <DownloadImageButton image={image} />
                     <DeleteImageButton image={image} />
                   </Space>

--- a/app/pages/CreationsPage/components/EditImageButton/EditImageButton.tsx
+++ b/app/pages/CreationsPage/components/EditImageButton/EditImageButton.tsx
@@ -58,7 +58,6 @@ const EditImageButton = ({ image }: { image: ImageType }) => {
       <Modal
         open={showEditImageModal}
         footer={false}
-        // onOk={() => formInstance.submit()}
         onCancel={toggleEditImageModal}
       >
         <div>

--- a/app/pages/CreationsPage/components/EditImageButton/EditImageButton.tsx
+++ b/app/pages/CreationsPage/components/EditImageButton/EditImageButton.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import { EditOutlined } from "@ant-design/icons";
+import {
+  Typography,
+  Button,
+  notification,
+  Modal,
+  Form,
+  Input,
+  Image,
+  Space,
+} from "antd";
+import type { ImageType } from "~/types";
+import { useRemixFetcher } from "~/hooks";
+import { fallbackImageSource } from "~/utils";
+
+const EditImageButton = ({ image }: { image: ImageType }) => {
+  const { fetcher, isLoadingFetcher } = useRemixFetcher({
+    // onSuccess: (response) => {
+    //   notification.success({ message: response.data.message });
+    // },
+    // onError: (error) => {
+    //   console.error(error);
+    //   notification.error({ message: error.data.message });
+    // },
+  });
+  const [formInstance] = Form.useForm();
+  const [showEditImageModal, setShowEditImageModal] = React.useState(false);
+  const toggleEditImageModal = () => setShowEditImageModal(!showEditImageModal);
+
+  const isLoadingData = isLoadingFetcher;
+
+  const handleSubmitEditImageData = () => {
+    formInstance.submit();
+  };
+
+  const handleSubmitForm = (formValues: { title: string }) => {
+    console.log(formValues);
+    toggleEditImageModal();
+
+    fetcher.submit(
+      { intent: "image-edit-image-data", body: JSON.stringify(formValues) },
+      { method: "PATCH", action: `api/image/${image.id}?index` }
+    );
+  };
+
+  return (
+    <>
+      <Button
+        size='small'
+        icon={<EditOutlined />}
+        style={{ border: "none", textAlign: "left" }}
+        loading={isLoadingData}
+        onClick={toggleEditImageModal}
+      >
+        Edit
+      </Button>
+      <Modal
+        open={showEditImageModal}
+        footer={false}
+        // onOk={() => formInstance.submit()}
+        onCancel={toggleEditImageModal}
+      >
+        <div>
+          <div
+            style={{
+              background: "#000",
+              width: "100%",
+              textAlign: "center",
+            }}
+          >
+            <Image
+              width={300}
+              src={image.url}
+              alt={image.title}
+              fallback={fallbackImageSource}
+              style={{ cursor: "pointer" }}
+            />
+          </div>
+          <div style={{ padding: 20 }}>
+            <div style={{ marginBottom: 12 }}>
+              <Typography.Text>Edit Image</Typography.Text>
+            </div>
+            <Form
+              form={formInstance}
+              layout='vertical'
+              colon={false}
+              initialValues={{ title: image.title || undefined }}
+              onFinish={handleSubmitForm}
+            >
+              <Form.Item label='Title' name='title'>
+                <Input placeholder='Enter title of image' />
+              </Form.Item>
+              <Form.Item label='Prompt'>
+                <Typography.Text italic>{image.prompt}</Typography.Text>
+              </Form.Item>
+            </Form>
+            <footer style={{ display: "flex", justifyContent: "flex-end" }}>
+              <Space>
+                <Button onClick={toggleEditImageModal}>Cancel</Button>
+                <Button onClick={handleSubmitEditImageData} type='primary'>
+                  OK
+                </Button>
+              </Space>
+            </footer>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default EditImageButton;

--- a/app/pages/CreationsPage/components/EditImageButton/index.ts
+++ b/app/pages/CreationsPage/components/EditImageButton/index.ts
@@ -1,0 +1,1 @@
+export { default as EditImageButton } from "./EditImageButton";

--- a/app/pages/CreationsPage/components/index.ts
+++ b/app/pages/CreationsPage/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./DeleteImageButton";
 export * from "./DownloadImageButton";
+export * from "./EditImageButton";

--- a/app/pages/ExplorePage/ExplorePage.tsx
+++ b/app/pages/ExplorePage/ExplorePage.tsx
@@ -17,9 +17,11 @@ import {
   Button,
   Popover,
   type RadioChangeEvent,
+  Tooltip,
 } from "antd";
 import type { ImageType } from "~/types";
 import { ImageModal, LikeImageButton } from "~/components";
+import { convertUtcDateToLocalDateString } from "~/utils";
 
 const ExplorePage = () => {
   const data = useLoaderData();
@@ -90,25 +92,26 @@ const ExplorePage = () => {
                       justifyContent: "space-between",
                     }}
                   >
-                    <Typography.Text
-                      ellipsis={{
-                        tooltip: (
-                          <Typography.Text>
+                    <Tooltip
+                      title={
+                        <Typography.Text>
+                          {image.title}
+                          <br />
+                          <Typography.Text italic>
                             {image.prompt}
                             <br />
                             <br />
-                            <Typography.Text italic>
-                              Created By: {image.user.username}
-                              <br />
-                              {new Date(image.createdAt).toLocaleString()}
-                            </Typography.Text>
+                            Created By: {image.user.username}
+                            <br />
+                            {convertUtcDateToLocalDateString(image.createdAt)}
                           </Typography.Text>
-                        ),
-                      }}
-                      style={{ maxWidth: 160 }}
+                        </Typography.Text>
+                      }
                     >
-                      {image.prompt}
-                    </Typography.Text>
+                      <Typography.Text ellipsis style={{ maxWidth: 160 }}>
+                        {image.title || "Untitled"}
+                      </Typography.Text>
+                    </Tooltip>
                     <Popover
                       content={
                         <Space size='small' align='center'>
@@ -153,27 +156,39 @@ const ExplorePage = () => {
                 <List.Item.Meta
                   style={{ margin: 0 }}
                   avatar={<ImageModal imageData={image} />}
-                  title={image.prompt}
+                  title={image.title || "Untitled"}
                   description={
                     <>
                       <div
                         style={{
                           display: "flex",
+                          flexDirection: "column",
                           justifyContent: "space-between",
                         }}
                       >
-                        <Typography.Text>
-                          Created By: {image.user.username}
+                        <Typography.Text italic style={{ marginBottom: 8 }}>
+                          {image.prompt}
                         </Typography.Text>
-                        <Typography.Text italic>
-                          {new Date(image.createdAt).toLocaleString()}
-                        </Typography.Text>
-                      </div>
-                      <div>
-                        <LikeImageButton imageData={image} />
-                        <Space style={{ color: "#64ffda" }}>
-                          <MessageOutlined />
-                          {image.comments.length > 0 && image.comments.length}
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            marginBottom: 8,
+                          }}
+                        >
+                          <Typography.Text>
+                            Created By: {image.user.username}
+                          </Typography.Text>
+                          <Typography.Text italic>
+                            {convertUtcDateToLocalDateString(image.createdAt)}
+                          </Typography.Text>
+                        </div>
+                        <Space>
+                          <LikeImageButton imageData={image} />
+                          <Space style={{ color: "#64ffda" }}>
+                            <MessageOutlined />
+                            {image.comments.length > 0 && image.comments.length}
+                          </Space>
                         </Space>
                       </div>
                     </>

--- a/app/routes/api/image/$imageId.tsx
+++ b/app/routes/api/image/$imageId.tsx
@@ -1,9 +1,0 @@
-import { type LoaderArgs, json } from "@remix-run/node";
-import { getImageBase64 } from "~/server";
-
-export const loader = async ({ request, params }: LoaderArgs) => {
-  const imageId = params?.imageId || "";
-  const data = await getImageBase64(imageId);
-
-  return json({ data });
-};

--- a/app/routes/api/image/$imageId/index.ts
+++ b/app/routes/api/image/$imageId/index.ts
@@ -1,0 +1,34 @@
+import { type LoaderArgs, type ActionArgs, json } from "@remix-run/node";
+import { getImageBase64, updateImageData } from "~/server";
+import { getSession } from "~/services";
+
+export const loader = async ({ request, params }: LoaderArgs) => {
+  const imageId = params?.imageId || "";
+  const data = await getImageBase64(imageId);
+
+  return json({ data });
+};
+
+export async function action({ request, params }: ActionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const googleSessionData = (await session.get("_session")) || undefined;
+  const userId = googleSessionData.id;
+  const imageId = params?.imageId || "";
+
+  if (!userId) {
+    throw new Error("Missing User ID: Must be logged in to Edit an Image");
+  }
+
+  switch (request.method.toUpperCase()) {
+    case "PATCH": {
+      const formData = await request.formData();
+      const payload = JSON.parse(formData.get("body") as string);
+      const response = await updateImageData(imageId, payload);
+
+      return response;
+    }
+    default: {
+      return {};
+    }
+  }
+}

--- a/app/server/getIcons/getIcons.ts
+++ b/app/server/getIcons/getIcons.ts
@@ -9,6 +9,7 @@ export const getIcons = async () => {
     },
     select: {
       id: true,
+      title: true,
       prompt: true,
       user: {
         select: {

--- a/app/server/getUserIcons/getUserIcons.ts
+++ b/app/server/getUserIcons/getUserIcons.ts
@@ -11,6 +11,7 @@ export const getUserIcons = async (userId: string) => {
     },
     select: {
       id: true,
+      title: true,
       prompt: true,
       user: {
         select: {

--- a/app/server/images/index.ts
+++ b/app/server/images/index.ts
@@ -1,3 +1,4 @@
 export * from "./toggleImageLikes";
 export * from "./createImageLike";
 export * from "./deleteImageLike";
+export * from "./updateImageData";

--- a/app/server/images/updateImageData.ts
+++ b/app/server/images/updateImageData.ts
@@ -1,0 +1,36 @@
+import { prisma } from "~/services/prisma.server";
+
+export const updateImageData = async (
+  imageId: string,
+  payload: { title: string }
+) => {
+  try {
+    const message = `Success updating Image Data for imageID: ${imageId}`;
+    const { title } = payload;
+
+    const data = await prisma.icon.update({
+      where: {
+        id: imageId,
+      },
+      data: {
+        title,
+      },
+    });
+
+    return {
+      success: true,
+      data,
+      message,
+    };
+  } catch (error) {
+    const message = `Error updating Image Data for imageID: ${imageId}`;
+    console.error(message);
+    console.error(error);
+    return {
+      success: false,
+      data: {},
+      message,
+      error,
+    };
+  }
+};

--- a/app/types/Images.d.ts
+++ b/app/types/Images.d.ts
@@ -22,7 +22,6 @@ export type ImageType = {
   title?: string;
   url: string;
   createdAt: Date;
-  // createdBy: string;
   user: {
     id: string;
     username: string;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,7 @@ model User {
 
 model Icon {
   id        String      @id @default(cuid())
-  title     String?
+  title     String?     @default("Untitled")
   prompt    String?
   user      User?       @relation(fields: [userId], references: [id])
   userId    String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,10 +61,10 @@ model User {
 
 model Icon {
   id        String      @id @default(cuid())
+  title     String?
   prompt    String?
   user      User?       @relation(fields: [userId], references: [id])
   userId    String?
-  createdBy String?
   createdAt DateTime    @default(now())
   comments  Comment[]
   likes     ImageLike[]


### PR DESCRIPTION
## Summary
Users can now add/edit the title of their images. At the moment users are only able to edit an image title on the `Creations Page` 

### UI Changes
Image titles are now viewable in `list` and `grid` views
<img width="1778" alt="CleanShot 2023-07-09 at 21 54 31@2x" src="https://github.com/kevinreber/ai-icon-generator/assets/42260999/52a51dff-254e-4d80-834f-c5509e410262">
<img width="1778" alt="CleanShot 2023-07-09 at 21 54 45@2x" src="https://github.com/kevinreber/ai-icon-generator/assets/42260999/9364cc13-17f1-4d15-b757-f68635622c53">


https://github.com/kevinreber/ai-icon-generator/assets/42260999/fb5efe4d-5cfc-4d61-8b83-520d3299e747

