### PR TITLE
[UI] Added image `preview` for images so user knows images are loading

### DIFF
--- a/app/components/ImageModal/ImageModal.tsx
+++ b/app/components/ImageModal/ImageModal.tsx
@@ -61,6 +61,8 @@ const ImageModal = ({
     <>
       <Image
         width={width}
+        // ? TODO: Should we make this into a smaller thumbnail URL so it loads faster?
+        // TODO: Look into AWS S3 auto generating thumbnails
         src={imageData.url}
         alt={imageData.prompt}
         fallback={fallbackImageSource}
@@ -250,6 +252,11 @@ const ImageModal = ({
                       labelStyle={{ fontWeight: 600 }}
                       colon={false}
                     >
+                      <Descriptions.Item label='Engine Model'>
+                        <Typography.Text italic>
+                          {imageData.model}
+                        </Typography.Text>
+                      </Descriptions.Item>
                       <Descriptions.Item label='Prompt'>
                         <Typography.Text italic>
                           {imageData.prompt}

--- a/app/components/ImageModal/ImageModal.tsx
+++ b/app/components/ImageModal/ImageModal.tsx
@@ -38,6 +38,8 @@ const ImageModal = ({
   const isUserLoggedIn = Boolean(loaderData.user);
   const [showImageModal, setShowImageModal] = React.useState(false);
   const [formInstance] = Form.useForm();
+  // `imagePreviewHeight` will be same as width so we have a cube
+  const imagePreviewHeight = width;
 
   const { fetcher, isLoadingFetcher } = useRemixFetcher({
     // onSuccess: (response) => {
@@ -65,6 +67,15 @@ const ImageModal = ({
         style={{ borderRadius: 8, cursor: "pointer" }}
         onClick={() => setShowImageModal(true)}
         preview={false}
+        placeholder={
+          <div
+            style={{
+              width,
+              height: imagePreviewHeight,
+              backgroundColor: "#d9d9d9",
+            }}
+          />
+        }
       />
       <Modal
         open={showImageModal}
@@ -94,12 +105,29 @@ const ImageModal = ({
               flexDirection: "column",
             }}
           >
-            <div style={{ width: "100%", maxWidth: 1024 }}>
+            <div
+              style={{
+                width: "100%",
+                maxWidth: 1024,
+                margin: "auto",
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
               <Image
                 src={imageData.url}
                 alt={imageData.prompt}
                 fallback={fallbackImageSource}
                 preview={false}
+                placeholder={
+                  <div
+                    style={{
+                      width: 1024,
+                      height: 1024,
+                      background: "black",
+                    }}
+                  />
+                }
               />
             </div>
           </div>

--- a/app/components/LikeImageButton/LikeImageButton.tsx
+++ b/app/components/LikeImageButton/LikeImageButton.tsx
@@ -1,4 +1,4 @@
-import { HeartOutlined, HeartTwoTone } from "@ant-design/icons";
+import { HeartFilled, HeartOutlined, HeartTwoTone } from "@ant-design/icons";
 import { Button } from "antd";
 import type { ImageType } from "~/types";
 import { useRemixFetcher } from "~/hooks";
@@ -27,21 +27,25 @@ const LikeImageButton = ({ imageData }: { imageData: ImageType }) => {
   const userLikesImage = imageData.likes.some((like) => like.userId === userId);
 
   const buttonIcon = userLikesImage ? (
-    <HeartTwoTone twoToneColor='#eb2f96' />
+    // <HeartTwoTone twoToneColor='#eb2f96' />
+    <HeartFilled style={{ color: "#eb2f96" }} />
   ) : (
-    <HeartOutlined style={{ color: "#eb2f96" }} />
+    <HeartOutlined style={{ color: "rgba(0, 0, 0, 0.45)" }} />
+    // <HeartOutlined style={{ color: "#eb2f96" }} />
   );
 
   return (
     <Button
       size='small'
-      style={{ border: "none" }}
+      style={{ border: "none", boxShadow: "none" }}
       icon={buttonIcon}
       onClick={handleLikeImage}
       loading={isLoadingFetcher}
       disabled={!userId}
     >
-      <span>{imageData.likes.length > 0 && imageData.likes.length}</span>
+      <span style={{ color: "rgba(0, 0, 0, 0.45)" }}>
+        {imageData.likes.length > 0 && imageData.likes.length}
+      </span>
     </Button>
   );
 };

--- a/app/pages/CollectionsPage/CollectionsPage.tsx
+++ b/app/pages/CollectionsPage/CollectionsPage.tsx
@@ -154,10 +154,10 @@ const CollectionsPage = () => {
                     >
                       <Tooltip
                         title={
-                          <Typography.Text>
+                          <Typography.Text style={{ color: "#fff" }}>
                             {image.title}
                             <br />
-                            <Typography.Text italic>
+                            <Typography.Text italic style={{ color: "#fff" }}>
                               {image.prompt}
                               <br />
                               <br />
@@ -248,7 +248,7 @@ const CollectionsPage = () => {
                         </div>
                         <Space>
                           <LikeImageButton imageData={image} />
-                          <Space style={{ color: "#64ffda" }}>
+                          <Space>
                             <MessageOutlined />
                             {image.comments.length > 0 && image.comments.length}
                           </Space>

--- a/app/pages/CreateImagePage/components/CreateImageForm/CreateImageForm.tsx
+++ b/app/pages/CreateImagePage/components/CreateImageForm/CreateImageForm.tsx
@@ -18,6 +18,7 @@ const DEFAULT_FORM_VALUES = {
   color: undefined,
   shape: undefined,
   numberOfImages: 1,
+  model: undefined,
 };
 
 const LANGUAGE_MODEL_OPTIONS = [

--- a/app/pages/ExplorePage/ExplorePage.tsx
+++ b/app/pages/ExplorePage/ExplorePage.tsx
@@ -105,10 +105,10 @@ const ExplorePage = () => {
                   >
                     <Tooltip
                       title={
-                        <Typography.Text>
+                        <Typography.Text style={{ color: "#fff" }}>
                           {image.title}
                           <br />
-                          <Typography.Text italic>
+                          <Typography.Text italic style={{ color: "#fff" }}>
                             {image.prompt}
                             <br />
                             <br />

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,11 +16,11 @@ import { getUserData } from "~/server";
 import { UserAvatar } from "./components";
 
 // CSS
-import globalStyles from "~/css/global.css";
+// import globalStyles from "~/css/global.css";
 
-export function links() {
-  return [{ rel: "stylesheet", href: globalStyles }];
-}
+// export function links() {
+//   return [{ rel: "stylesheet", href: globalStyles }];
+// }
 
 export let loader = async ({ request }: LoaderArgs) => {
   const user = await authenticator.isAuthenticated(request);

--- a/app/server/addNewImageToDB/addNewImageToDB.ts
+++ b/app/server/addNewImageToDB/addNewImageToDB.ts
@@ -4,11 +4,18 @@ import { prisma } from "~/services/prisma.server";
  * @description
  * This function creates a new image in our DB
  */
-export const addNewImageToDB = async (prompt: string, userId: string) => {
+export const addNewImageToDB = async (
+  prompt: string,
+  userId: string,
+  model: string,
+  preset = "none"
+) => {
   const image = await prisma.icon.create({
     data: {
       prompt,
       userId,
+      model,
+      stylePreset: preset,
     },
   });
 

--- a/app/server/createImageFromDallEAPI/createImageFromDallEAPI.ts
+++ b/app/server/createImageFromDallEAPI/createImageFromDallEAPI.ts
@@ -57,7 +57,7 @@ export const createImageFromDallEAPI = async (
   formData = DEFAULT_PAYLOAD,
   userId: string
 ) => {
-  const { prompt, numberOfImages } = formData;
+  const { prompt, numberOfImages, model } = formData;
 
   try {
     if (process.env.USE_MOCK_DALLE === "true") {
@@ -76,7 +76,7 @@ export const createImageFromDallEAPI = async (
     const formattedImageData = await Promise.all(
       imagesImages.map(async (imageImage) => {
         // Store Image into DB
-        const imageData = await addNewImageToDB(prompt, userId);
+        const imageData = await addNewImageToDB(prompt, userId, model);
         console.log("Stored Image Data in DB: ", imageData.id);
 
         // Store Image blob in S3

--- a/app/server/createImageFromStableDiffusionAPI/createImageFromStableDiffusionAPI.ts
+++ b/app/server/createImageFromStableDiffusionAPI/createImageFromStableDiffusionAPI.ts
@@ -119,7 +119,12 @@ export const createImageFromStableDiffusionAPI = async (
       images.artifacts.map(async (image) => {
         if (image.finishReason !== "ERROR") {
           // Store Image into DB
-          const imageData = await addNewImageToDB(prompt, userId);
+          const imageData = await addNewImageToDB(
+            prompt,
+            userId,
+            model,
+            stylePreset
+          );
           console.log("Stored Image Data in DB: ", imageData.id);
 
           // Store Image blob in S3

--- a/app/server/getImages/getImages.ts
+++ b/app/server/getImages/getImages.ts
@@ -18,6 +18,8 @@ export const getImages = async (
       id: true,
       title: true,
       prompt: true,
+      model: true,
+      stylePreset: true,
       user: {
         select: {
           id: true,

--- a/app/server/getUserImages/getUserImages.ts
+++ b/app/server/getUserImages/getUserImages.ts
@@ -27,6 +27,8 @@ export const getUserImages = async (
       id: true,
       title: true,
       prompt: true,
+      model: true,
+      stylePreset: true,
       user: {
         select: {
           id: true,

--- a/app/types/Images.d.ts
+++ b/app/types/Images.d.ts
@@ -19,6 +19,8 @@ export type Comment = {
 export type ImageType = {
   id: string;
   prompt: string;
+  model: string;
+  stylePreset?: string;
   title?: string;
   url: string;
   createdAt: Date;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,14 +60,16 @@ model User {
 }
 
 model Icon {
-  id        String      @id @default(cuid())
-  title     String?     @default("Untitled")
-  prompt    String?
-  user      User?       @relation(fields: [userId], references: [id])
-  userId    String?
-  createdAt DateTime    @default(now())
-  comments  Comment[]
-  likes     ImageLike[]
+  id          String      @id @default(cuid())
+  title       String?     @default("Untitled")
+  prompt      String?
+  model       String?     @default("dall-e")
+  stylePreset String?     @default("none")
+  user        User?       @relation(fields: [userId], references: [id])
+  userId      String?
+  createdAt   DateTime    @default(now())
+  comments    Comment[]
+  likes       ImageLike[]
 }
 
 model ImageLike {


### PR DESCRIPTION
## Summary
Our images currently do not have a `preview`, so our UI/UX looks a little jumpy when the images load.

These images can be huge files _(1024 x 1024px - 3.0mb)_ and can take awhile to finish rendering. This `preview` makes our UI/UX less jumpy and helps users better understand that images are loading in the background.
![CleanShot 2023-07-30 at 12 04 47@2x](https://github.com/kevinreber/ai-icon-generator/assets/42260999/17c7e68e-d450-4699-b3f8-62a1dd38dc13)

Also updated DB to store an Image's `model` and `stylePreset` values.

## Follow up
Look into creating image thumbnails using AWS S3 Lambda functions: https://docs.aws.amazon.com/lambda/latest/dg/with-s3-tutorial.html
