### PR TITLE
[Feature] Added `Preset` style and `Add Images to Collection` for Create Images Page

### DIFF
--- a/app/components/AddImagesToCollectionButton/AddImagesToCollectionButton.tsx
+++ b/app/components/AddImagesToCollectionButton/AddImagesToCollectionButton.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { BookOutlined } from "@ant-design/icons";
+import { Button, Checkbox, Popover, Space, Typography } from "antd";
+import type { ImageType } from "~/types";
+import { useRemixFetcher } from "~/hooks";
+import { UserContext } from "~/context";
+import { CreateCollectionButton } from "~/components";
+import { useActionData, useNavigation } from "@remix-run/react";
+import { CreateImagePageActionData } from "~/routes/create._index";
+
+const getImageIds = (collections: any[]) => {
+  const imageIds: string[] = [];
+
+  collections.forEach((collection) => {
+    collection.images.forEach((image: { imageId: string }) => {
+      imageIds.push(image.imageId);
+    });
+  });
+
+  return imageIds;
+};
+
+const AddImagesToCollectionButton = ({ images }: { images: ImageType[] }) => {
+  const userData = React.useContext(UserContext);
+  const userId = userData?.id || undefined;
+
+  const actionData = useActionData() as CreateImagePageActionData;
+  // const navigation = useNavigation();
+  // const isLoadingData = navigation.state !== "idle";
+
+  console.log(actionData);
+
+  const imagesGenerated = Boolean(actionData && actionData.images);
+  const imagesIds = images.map((image) => image.id);
+
+  const { fetcher, isLoadingFetcher } = useRemixFetcher({
+    // onSuccess: (response) => {
+    //   const successMessage =
+    //     response.data.message || "Successfully added Image to Collection";
+    //   notification.success({ message: successMessage });
+    // },
+    // onError: (error) => {
+    //   const errorMessage =
+    //     error.data.message || "Error adding Image to Collection";
+    //   console.error(error);
+    //   notification.error({ message: errorMessage });
+    // },
+  });
+  const [showUserCollectionsPopover, setShowUserCollectionsPopover] =
+    React.useState(false);
+
+  const userCollections = userData.collections || [];
+  const userCollectionImages = getImageIds(userCollections);
+
+  const toggleUserCollectionsPopover = () => {
+    setShowUserCollectionsPopover(!showUserCollectionsPopover);
+  };
+
+  const handleAddImagesToCollection = (event: any) => {
+    const collectionId = event.target.value;
+    // User must be logged in to add an Image to a Collection
+    if (!userId) {
+      return;
+    }
+
+    fetcher.submit(
+      {
+        intent: "_add-image-to-collection",
+        body: JSON.stringify({ images: imagesIds }),
+      },
+      {
+        method: "POST",
+        action: `/api/collections/${collectionId}/images?index`,
+      },
+    );
+    toggleUserCollectionsPopover();
+  };
+
+  return (
+    <>
+      <Popover
+        open={showUserCollectionsPopover}
+        title={
+          <>
+            {userCollections.length ? (
+              <Space direction="vertical">
+                <CreateCollectionButton />
+                {userCollections.map((collection) => {
+                  const isCollectionChecked = userCollectionImages.some(
+                    (imageId) => imagesIds.includes(imageId),
+                  );
+
+                  return (
+                    <Checkbox
+                      key={collection.id}
+                      value={collection.id}
+                      onClick={handleAddImagesToCollection}
+                      checked={isCollectionChecked}
+                      style={{ padding: 4 }}
+                    >
+                      {collection.title}
+                    </Checkbox>
+                  );
+                })}
+              </Space>
+            ) : (
+              <Typography.Text italic type="secondary">
+                No Collections
+              </Typography.Text>
+            )}
+          </>
+        }
+      >
+        <Button
+          icon={<BookOutlined />}
+          onClick={toggleUserCollectionsPopover}
+          loading={isLoadingFetcher}
+          disabled={!userId || !imagesGenerated}
+        >
+          Add images to Collection
+        </Button>
+      </Popover>
+    </>
+  );
+};
+
+export default AddImagesToCollectionButton;

--- a/app/components/AddImagesToCollectionButton/AddImagesToCollectionButton.tsx
+++ b/app/components/AddImagesToCollectionButton/AddImagesToCollectionButton.tsx
@@ -25,8 +25,8 @@ const AddImagesToCollectionButton = ({ images }: { images: ImageType[] }) => {
   const userId = userData?.id || undefined;
 
   const actionData = useActionData() as CreateImagePageActionData;
-  // const navigation = useNavigation();
-  // const isLoadingData = navigation.state !== "idle";
+  const navigation = useNavigation();
+  const isLoadingData = navigation.state !== "idle";
 
   console.log(actionData);
 
@@ -115,7 +115,7 @@ const AddImagesToCollectionButton = ({ images }: { images: ImageType[] }) => {
           icon={<BookOutlined />}
           onClick={toggleUserCollectionsPopover}
           loading={isLoadingFetcher}
-          disabled={!userId || !imagesGenerated}
+          disabled={!userId || !imagesGenerated || isLoadingData}
         >
           Add images to Collection
         </Button>

--- a/app/components/AddImagesToCollectionButton/index.ts
+++ b/app/components/AddImagesToCollectionButton/index.ts
@@ -1,0 +1,1 @@
+export { default as AddImagesToCollectionButton } from "./AddImagesToCollectionButton";

--- a/app/components/GeneralErrorBoundary.tsx
+++ b/app/components/GeneralErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import {
+  isRouteErrorResponse,
+  useParams,
+  useRouteError,
+} from "@remix-run/react";
+import { type ErrorResponse } from "@remix-run/router";
+import { getErrorMessage } from "~/utils";
+
+type StatusHandler = (info: {
+  error: ErrorResponse;
+  params: Record<string, string | undefined>;
+}) => JSX.Element | null;
+
+export function GeneralErrorBoundary({
+  defaultStatusHandler = ({ error }) => (
+    <p>
+      {error.status} {error.data}
+    </p>
+  ),
+  statusHandlers,
+  unexpectedErrorHandler = (error) => <p>{getErrorMessage(error)}</p>,
+}: {
+  defaultStatusHandler?: StatusHandler;
+  statusHandlers?: Record<number, StatusHandler>;
+  unexpectedErrorHandler?: (error: unknown) => JSX.Element | null;
+}) {
+  const error = useRouteError();
+  const params = useParams();
+
+  if (typeof document !== "undefined") {
+    console.error(error);
+  }
+
+  return (
+    <div className="container mx-auto flex h-full w-full items-center justify-center bg-destructive p-20 text-h2 text-destructive-foreground">
+      {isRouteErrorResponse(error)
+        ? (statusHandlers?.[error.status] ?? defaultStatusHandler)({
+            error,
+            params,
+          })
+        : unexpectedErrorHandler(error)}
+    </div>
+  );
+}

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -9,3 +9,5 @@ export * from "./AddImageToCollectionButton";
 export * from "./DeleteCollectionButton";
 export * from "./EditCollectionButton";
 export * from "./CreateCollectionButton";
+export * from "./AddImagesToCollectionButton";
+export * from "./GeneralErrorBoundary";

--- a/app/pages/CreateImagePage/CreateImagePage.tsx
+++ b/app/pages/CreateImagePage/CreateImagePage.tsx
@@ -1,9 +1,10 @@
-import { Typography, Image, Card, Row, Col } from "antd";
+import { Typography, Image, Card, Row, Col, Space } from "antd";
 import { CreateImageForm } from "./components";
 import { useActionData, useNavigation } from "@remix-run/react";
 import { fallbackImageSource } from "~/utils";
 import type { ImageType } from "~/types";
-import { type CreateImagePageActionData } from "~/routes/create";
+import { type CreateImagePageActionData } from "~/routes/create._index";
+import { AddImagesToCollectionButton } from "~/components";
 
 const CreateImagePage = () => {
   const actionData = useActionData() as CreateImagePageActionData;
@@ -21,7 +22,11 @@ const CreateImagePage = () => {
         <CreateImageForm />
       </Col>
       <Col span={12}>
-        <Typography.Title level={3}>Images Generated</Typography.Title>
+        <Space style={{ display: "flex", justifyContent: "space-between" }}>
+          <Typography.Title level={3}>Images Generated</Typography.Title>
+          <AddImagesToCollectionButton images={actionData?.images || []} />
+        </Space>
+
         <Card
           loading={isLoadingData}
           style={{ minHeight: 400 }}

--- a/app/pages/CreateImagePage/components/CreateImageForm/CreateImageForm.tsx
+++ b/app/pages/CreateImagePage/components/CreateImageForm/CreateImageForm.tsx
@@ -11,7 +11,11 @@ import {
   Select,
 } from "antd";
 import { COLOR_PICKER_PRESET_OPTIONS } from "app/utils";
-import { ICON_SHAPE_OPTIONS, ICON_STYLE_OPTIONS } from "./constants";
+import {
+  ICON_SHAPE_OPTIONS,
+  ICON_STYLE_OPTIONS,
+  STABLE_DIFFUSION_IMAGE_PRESETS,
+} from "./constants";
 
 const DEFAULT_FORM_VALUES = {
   prompt: undefined,
@@ -100,13 +104,14 @@ const CreateImageForm = () => {
         />
       </Form.Item> */}
 
-      {/* TODO */}
-      {/* <Form.Item label='Select a style for your Image' name='style'>
-        <Radio.Group
-          options={ICON_STYLE_OPTIONS}
-          // optionType="button"
+      <Form.Item label="Select a style for your Image" name="style">
+        <Select
+          options={STABLE_DIFFUSION_IMAGE_PRESETS}
+          placeholder="Ex: anime"
+          allowClear
+          showSearch
         />
-      </Form.Item> */}
+      </Form.Item>
 
       {/* TODO */}
       {/* <Form.Item label='Select shape of Image' name='shape'>

--- a/app/pages/CreateImagePage/components/CreateImageForm/constants.tsx
+++ b/app/pages/CreateImagePage/components/CreateImageForm/constants.tsx
@@ -1,3 +1,23 @@
+export const STABLE_DIFFUSION_IMAGE_PRESETS = [
+  { value: "3d-model", label: "3d-model" },
+  { value: "analog-film", label: "analog-film" },
+  { value: "anime", label: "anime" },
+  { value: "cinematic", label: "cinematic" },
+  { value: "comic-book", label: "comic-book" },
+  { value: "digital-art", label: "digital-art" },
+  { value: "enhance", label: "enhance" },
+  { value: "fantasy-art", label: "fantasy-art" },
+  { value: "isometric", label: "isometric" },
+  { value: "line-art", label: "line-art" },
+  { value: "low-poly", label: "low-poly" },
+  { value: "modeling-compound", label: "modeling-compound" },
+  { value: "neon-punk", label: "neon-punk" },
+  { value: "origami", label: "origami" },
+  { value: "photographic", label: "photographic" },
+  { value: "pixel-art", label: "pixel-art" },
+  { value: "tile-texture", label: "tile-texture" },
+];
+
 export const ICON_STYLE_OPTIONS = [
   {
     value: "metallic",

--- a/app/routes/$.tsx
+++ b/app/routes/$.tsx
@@ -1,0 +1,40 @@
+// This is called a "splat route" and as it's in the root `/app/routes/`
+// directory, it's a catchall. If no other routes match, this one will and we
+// can know that the user is hitting a URL that doesn't exist. By throwing a
+// 404 from the loader, we can force the error boundary to render which will
+// ensure the user gets the right status code and we can display a nicer error
+// message for them than the Remix and/or browser default.
+
+import { Button, Result } from "antd";
+import { GeneralErrorBoundary } from "~/components/GeneralErrorBoundary";
+
+export async function loader() {
+  throw new Response("Not found", { status: 404 });
+}
+
+export default function NotFound() {
+  // due to the loader, this component will never be rendered, but we'll return
+  // the error boundary just in case.
+  return <ErrorBoundary />;
+}
+
+export function ErrorBoundary() {
+  return (
+    <GeneralErrorBoundary
+      statusHandlers={{
+        404: () => (
+          <Result
+            status="404"
+            title="404"
+            subTitle="Sorry, the page you visited does not exist."
+            extra={
+              <Button type="primary" href="/">
+                Back to Home
+              </Button>
+            }
+          />
+        ),
+      }}
+    />
+  );
+}

--- a/app/routes/api.collections.$collectionId.images._index.ts
+++ b/app/routes/api.collections.$collectionId.images._index.ts
@@ -1,6 +1,17 @@
-import { type LoaderFunctionArgs, json, redirect } from "@remix-run/node";
-import { getCollectionData } from "~/server";
+import {
+  type LoaderFunctionArgs,
+  json,
+  redirect,
+  type ActionFunctionArgs,
+} from "@remix-run/node";
+import {
+  addImageToCollection,
+  removeImageFromCollection,
+  getCollectionData,
+} from "~/server";
+import { getSession } from "~/services";
 import { authenticator } from "~/services/auth.server";
+import { prisma } from "~/services/prisma.server";
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   await authenticator.isAuthenticated(request, {
@@ -15,3 +26,57 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
 
   return json({ data: collectionData });
 };
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const googleSessionData = (await session.get("_session")) || undefined;
+  const userId = googleSessionData.id;
+  const collectionId = params.collectionId || "";
+
+  if (!userId) {
+    throw new Error("Missing User ID: Must be logged in to Delete Collection");
+  }
+
+  switch (request.method.toUpperCase()) {
+    case "POST": {
+      const formData = await request.formData();
+      const payload = formData.get("body");
+      const formattedPayload = await JSON.parse(payload as string);
+      const images: string[] = formattedPayload.images;
+      const dataResponse: any = [];
+
+      await Promise.all(
+        images.map(async (imageId) => {
+          let data;
+          const collectionHasImage = await prisma.collectionHasImage.findMany({
+            where: {
+              collectionId,
+              imageId,
+            },
+          });
+
+          // If Collection already has Image, remove Image from Collection
+          if (collectionHasImage.length > 0) {
+            data = await removeImageFromCollection({
+              collectionId,
+              imageId,
+            });
+          } else {
+            data = await addImageToCollection({
+              collectionId,
+              imageId,
+            });
+          }
+          dataResponse.push(data);
+        }),
+      ).catch((error) => {
+        console.error(error);
+      });
+
+      return dataResponse;
+    }
+    default: {
+      return {};
+    }
+  }
+}

--- a/app/server/addNewImageToDB/addNewImageToDB.ts
+++ b/app/server/addNewImageToDB/addNewImageToDB.ts
@@ -14,7 +14,7 @@ export const addNewImageToDB = async ({
   prompt: string;
   userId: string;
   model: string;
-  preset: string;
+  preset?: string;
   isImagePrivate: boolean;
 }) => {
   const image = await prisma.icon.create({

--- a/app/server/createImageFromStableDiffusionAPI/createImageFromStableDiffusionAPI.ts
+++ b/app/server/createImageFromStableDiffusionAPI/createImageFromStableDiffusionAPI.ts
@@ -9,7 +9,7 @@ const THREE_SECONDS_IN_MS = 1000 * 3;
 
 const DEFAULT_NUMBER_OF_IMAGES_CREATED = 1;
 const DEFAULT_AI_IMAGE_LANGUAGE_MODEL = "stable-diffusion-xl";
-const DEFAULT_IMAGE_STYLE_PRESET = "enhance";
+const DEFAULT_IMAGE_STYLE_PRESET = undefined;
 const DEFAULT_IS_IMAGE_PRIVATE = false;
 
 const DEFAULT_PAYLOAD = {
@@ -53,12 +53,13 @@ const createStableDiffusionImages = async (
     cfg_scale: 7,
     height: IMAGE_HEIGHT,
     width: IMAGE_WIDTH,
-    steps: 30,
+    steps: 40,
     style_preset: stylePreset,
     samples: numberOfImagesToGenerate,
     text_prompts: [
       {
         text: promptMessage,
+        weight: 1,
       },
     ],
   };

--- a/app/server/createNewImages/createNewImages.ts
+++ b/app/server/createNewImages/createNewImages.ts
@@ -7,7 +7,7 @@ import {
 
 const DEFAULT_NUMBER_OF_IMAGES_CREATED = 1;
 const DEFAULT_AI_IMAGE_LANGUAGE_MODEL = "stable-diffusion-xl";
-const DEFAULT_IMAGE_STYLE_PRESET = "enhance";
+const DEFAULT_IMAGE_STYLE_PRESET = undefined;
 const DEFAULT_IS_IMAGE_PRIVATE = false;
 
 const DEFAULT_PAYLOAD = {

--- a/app/types/Collections.d.ts
+++ b/app/types/Collections.d.ts
@@ -7,7 +7,7 @@ export type Collection = {
   user: { id: string; username: string };
   createdAt: Date | string;
   updatedAt: Date | string;
-  images: Pick<ImageType, "id">[];
+  images: string[];
 };
 
 export type GetUserCollectionsAPIResponse = {

--- a/app/utils/getErrorMessage.ts
+++ b/app/utils/getErrorMessage.ts
@@ -1,0 +1,16 @@
+/**
+ * Does its best to get a string error message from an unknown error.
+ */
+export const getErrorMessage = (error: unknown) => {
+  if (typeof error === "string") return error;
+  if (
+    error &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+  console.error("Unable to get error message for error", error);
+  return "Unknown Error";
+};

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -9,3 +9,5 @@ export * from "./getPaginationRange";
 export * from "./convertNumberToLocaleString";
 export * from "./getS3BucketThumbnailURL";
 export * from "./removeEmptyValuesFromObject";
+export * from "./getErrorMessage";
+export * from "./invariantResponse";

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -10,4 +10,4 @@ export * from "./convertNumberToLocaleString";
 export * from "./getS3BucketThumbnailURL";
 export * from "./removeEmptyValuesFromObject";
 export * from "./getErrorMessage";
-export * from "./invariantResponse";
+// export * from "./invariantResponse";


### PR DESCRIPTION
## Summary
1. Added `Preset` to be selected when generating images and users can now save images to new collection on the Create Images Page after images creation
![CleanShot 2023-11-04 at 22 21 46@2x](https://github.com/kevinreber/ai-icon-generator/assets/42260999/c22da0d1-3855-44c8-b915-f6afb64b9db2)
2. Added splat route to render if user visit a route that does not exist
![CleanShot 2023-11-04 at 22 26 11@2x](https://github.com/kevinreber/ai-icon-generator/assets/42260999/88047725-f2c0-4fe4-8a11-1631b52b15d2)
3. Added Generic Error Boundary that can be used anywhere and customized
```tsx
import {
	isRouteErrorResponse,
	useParams,
	useRouteError,
} from '@remix-run/react'
import { type ErrorResponse } from '@remix-run/router'
import { getErrorMessage } from '#app/utils/misc.tsx'

type StatusHandler = (info: {
	error: ErrorResponse
	params: Record<string, string | undefined>
}) => JSX.Element | null

export function GeneralErrorBoundary({
	defaultStatusHandler = ({ error }) => (
		<p>
			{error.status} {error.data}
		</p>
	),
	statusHandlers,
	unexpectedErrorHandler = error => <p>{getErrorMessage(error)}</p>,
}: {
	defaultStatusHandler?: StatusHandler
	statusHandlers?: Record<number, StatusHandler>
	unexpectedErrorHandler?: (error: unknown) => JSX.Element | null
}) {
	const error = useRouteError()
	const params = useParams()

	if (typeof document !== 'undefined') {
		console.error(error)
	}

	return (
		<div className="container mx-auto flex h-full w-full items-center justify-center bg-destructive p-20 text-h2 text-destructive-foreground">
			{isRouteErrorResponse(error)
				? (statusHandlers?.[error.status] ?? defaultStatusHandler)({
						error,
						params,
				  })
				: unexpectedErrorHandler(error)}
		</div>
	)
}
```
References
- Epic Web – handling 404 Errors with Splat Routes: https://www.epicweb.dev/workshops/full-stack-foundations/error-handling/handling-404-errors-in-react-router-with-splat-routes
