### PR TITLE
Removed navigation bar for mobile if user is not logged in

### DIFF
--- a/app/components/NavigationSidebar/NavigationSidebar.tsx
+++ b/app/components/NavigationSidebar/NavigationSidebar.tsx
@@ -46,15 +46,7 @@ const NavigationSidebar = () => {
     },
   ];
 
-  const navLinksToRender = isLoggedIn
-    ? NAV_LINKS
-    : [
-        {
-          title: "Explore",
-          icon: <SearchOutlined />,
-          href: "/explore",
-        },
-      ];
+  const navLinksToRender = isLoggedIn ? NAV_LINKS : [];
 
   return (
     <>
@@ -175,22 +167,25 @@ const NavigationSidebar = () => {
               </div>
             )}
           </div>
-          <div
-            className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-around bg-black py-4"
-            style={{
-              borderTop: "rgb(38, 38, 38) 1px solid",
-            }}
-          >
-            {navLinksToRender.map((link) => (
-              <Link
-                className="text-white group flex items-center px-2 py-2 text-medium font-medium rounded-md"
-                // className="bg-gray-900 text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md"
-                to={link.href}
-              >
-                <span>{link.icon}</span>
-              </Link>
-            ))}
-          </div>
+
+          {isLoggedIn && (
+            <div
+              className="fixed bottom-0 left-0 right-0 z-10 flex items-center justify-around bg-black py-4"
+              style={{
+                borderTop: "rgb(38, 38, 38) 1px solid",
+              }}
+            >
+              {navLinksToRender.map((link) => (
+                <Link
+                  className="text-white group flex items-center px-2 py-2 text-medium font-medium rounded-md"
+                  // className="bg-gray-900 text-white group flex items-center px-2 py-2 text-sm font-medium rounded-md"
+                  to={link.href}
+                >
+                  <span>{link.icon}</span>
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/app/pages/LandingPage/LandingPage.tsx
+++ b/app/pages/LandingPage/LandingPage.tsx
@@ -105,6 +105,12 @@ const LandingPage = () => {
                     >
                       Get started
                     </a>
+                    <a
+                      href="/explore"
+                      className="rounded-md px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 border border-gray-500 hover:bg-gray-800 hover:text-gray-200"
+                    >
+                      Explore
+                    </a>
                   </div>
                 </div>
                 <div className="mt-14 flex justify-end gap-8 sm:-mt-44 sm:justify-start sm:pl-20 lg:mt-0 lg:pl-0">


### PR DESCRIPTION
## Summary
Having only the "Explore" menu show when a user wasn't logged in look a little strange. Removed the navigation side bar for mobile view if a user is not logged in

**BEFORE**
![CleanShot 2024-02-18 at 17 00 32](https://github.com/kevinreber/ai-icon-generator/assets/42260999/cd3dad26-b7f8-4a77-953f-f0dda22ff9e6)


**AFTER**
![CleanShot 2024-02-18 at 16 57 30](https://github.com/kevinreber/ai-icon-generator/assets/42260999/038855a7-5abf-42cf-9466-90bd3a60a4ed)
